### PR TITLE
feat: add fuse for a custom v8 snapshot path for the browser process

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ await flipFuses(
     [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false, // Disables the NODE_OPTIONS environment variable
     [FuseV1Options.EnableNodeCliInspectArguments]: false, // Disables the --inspect and --inspect-brk family of ClI options
     [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true, // Enables validation of the app.asar archive on macOS
-    [FuseV1Options.OnlyLoadAppFromAsar]: true, // Enforces that Electron will only load your app from "app.asar" instead of it's normall search paths
+    [FuseV1Options.OnlyLoadAppFromAsar]: true, // Enforces that Electron will only load your app from "app.asar" instead of it's normal search paths
+    [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: true, // Loads V8 Snapshot from `browser_v8_context_snapshot.bin` for the browser process
   },
 );
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export enum FuseV1Options {
   EnableNodeCliInspectArguments = 3,
   EnableEmbeddedAsarIntegrityValidation = 4,
   OnlyLoadAppFromAsar = 5,
+  LoadBrowserProcessSpecificV8Snapshot = 6,
 }
 
 export type FuseV1Config<T = boolean> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const buildFuseV1Wire = (config: FuseV1Config, wireLength: number) => {
     state(config[FuseV1Options.EnableNodeCliInspectArguments]),
     state(config[FuseV1Options.EnableEmbeddedAsarIntegrityValidation]),
     state(config[FuseV1Options.OnlyLoadAppFromAsar]),
+    state(config[FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]),
   ];
 };
 


### PR DESCRIPTION
Add a fuse for a custom v8 snapshot path for the browser process. This is the corresponding PR to this PR:

https://github.com/electron/electron/pull/35266