### PR TITLE
fix: fix broken resetAdHocDarwinSignature option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export const flipFuses = async (
   pathToElectron: string,
   fuseConfig: FuseConfig,
 ): Promise<number> => {
-  let numSentinels;
+  let numSentinels: number;
 
   switch (fuseConfig.version) {
     case FuseVersion.V1:

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,14 +150,17 @@ export const flipFuses = async (
   pathToElectron: string,
   fuseConfig: FuseConfig,
 ): Promise<number> => {
+  let numSentinels;
+
   switch (fuseConfig.version) {
     case FuseVersion.V1:
-      return await setFuseWire(
+      numSentinels = await setFuseWire(
         pathToElectron,
         fuseConfig.version,
         buildFuseV1Wire.bind(null, fuseConfig),
         (i) => FuseV1Options[i],
       );
+      break;
     default:
       throw new Error(`Unsupported fuse version number: ${fuseConfig.version}`);
   }
@@ -178,4 +181,6 @@ export const flipFuses = async (
       throw new Error(`Ad-hoc codesign failed with status: ${result.status}`);
     }
   }
+
+  return numSentinels;
 };


### PR DESCRIPTION
The `resetAdHocDarwinSignature` option was broken by the changes in https://github.com/electron/fuses/commit/b9293a7e92dafc791ce1b9ceb903f5f1552d7307 due to returning early from `flipFuses`, skipping the handling of this option. Let's fix this by avoiding the early return.

This issues is present in version 1.6.0 of `@electron/fuses` on NPM, which is how I ran across this issue.

Tested by setting the `resetAdHocDarwinSignature` option when flipping fuses on an ARM64 Mac, the resulting binary can now be run successfully instead of running into code signing errors.