### PR TITLE
ci: bump Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - test
   test-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.3.0"
     resource_class: macos.x86.medium.gen2
     steps:
       - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - test
   test-mac:
     macos:
-      xcode: "13.0.0"
+      xcode: "14.0.0"
     resource_class: macos.x86.medium.gen2
     steps:
       - install


### PR DESCRIPTION
The current version is deprecated on CircleCI and will be sunset in the next couple of months.