### PR TITLE
build: remove link from package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dist",
     "README.md"
   ],
-  "description": "Flip [Electron Fuses](https://github.com/electron/electron/blob/master/docs/tutorial/fuses.md) and customize your packaged build of Electron",
+  "description": "Flip Electron Fuses and customize your packaged build of Electron",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/electron/fuses.git"


### PR DESCRIPTION
It doesn't look very nice when searching on npm, and the link is in the README so nothing is really lost by not linking in the package description.

<img width="1082" alt="Screenshot 2023-07-21 at 12 17 28 AM" src="https://github.com/electron/fuses/assets/5820654/4c40d452-164e-45a7-94ae-8b0f4cbe000b">
