### PR TITLE
chore: fix typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const setFuseWire = async (
   for (const indexOfSentinel of sentinels) {
     if (indexOfSentinel === -1) {
       throw new Error(
-        'Could not find sentinel in the provided ELectron binary, fuses are only supported in Electron 12 and higher',
+        'Could not find sentinel in the provided Electron binary, fuses are only supported in Electron 12 and higher',
       );
     }
 
@@ -125,7 +125,7 @@ export const getCurrentFuseWire = async (
 
   if (fuseWirePosition - SENTINEL.length === -1) {
     throw new Error(
-      'Could not find sentinel in the provided ELectron binary, fuses are only supported in Electron 12 and higher',
+      'Could not find sentinel in the provided Electron binary, fuses are only supported in Electron 12 and higher',
     );
   }
   const fuseWireVersion = (electron[fuseWirePosition] as any) as FuseVersion;


### PR DESCRIPTION
A small typo fix: ELectron => Electron.