### PR TITLE
feat: add strict mode to hard fail when new fuses added without explicit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,24 @@ await flipFuses(
   },
 );
 ```
+
+### New Fuses
+
+If you want to ensure you provide a config for every fuse, even newly added fuses during Electron upgrades
+you can set the `strictlyRequireAllFuses` option to `true`. This will hard fail the build if you are on
+a version of `@electron/fuses` that doesn't have configuration options for every fuse in the Electron binary
+you are targetting or if you don't provide a configuration for a specific fuse present in the Electron binary
+you are targetting.
+
+```typescript
+import { flipFuses, FuseVersion, FuseV1Options } from '@electron/fuses';
+
+await flipFuses(
+  require('electron'),
+  {
+    version: FuseVersion.V1,
+    strictlyRequireAllFuses: true,
+    [FuseV1Options.RunAsNode]: false,
+  },
+);
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,9 @@ export type FuseV1Config<T = boolean> = {
    * defaults to "false"
    */
   strictlyRequireAllFuses?: boolean;
-} & Partial<Record<FuseV1Options, T>>;
+} & (
+  | (Partial<Record<FuseV1Options, T>> & { strictlyRequireAllFuses?: false | undefined })
+  | (Record<FuseV1Options, T> & { strictlyRequireAllFuses: true })
+);
 
 export type FuseConfig<T = boolean> = FuseV1Config<T>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,15 @@ export enum FuseV1Options {
 export type FuseV1Config<T = boolean> = {
   version: FuseVersion.V1;
   resetAdHocDarwinSignature?: boolean;
+  /**
+   * Ensures that all fuses in the fuse wire being set have been defined to a set value
+   * by the provided config. Set this to true to ensure you don't accidentally miss a
+   * fuse being added in future Electron upgrades.
+   *
+   * This option may default to "true" in a future version of @electron/fuses but currently
+   * defaults to "false"
+   */
+  strictlyRequireAllFuses?: boolean;
 } & Partial<Record<FuseV1Options, T>>;
 
 export type FuseConfig<T = boolean> = FuseV1Config<T>;


### PR DESCRIPTION
Just so some folks can opt in to not missing fuses, both type safe and runtime safe