### PR TITLE
fix: replace extract-zip with @electron-internal/extract-zip

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,5 +6,6 @@ npmMinimalAgeGate: 10080
 
 npmPreapprovedPackages:
   - "@electron/*"
+  - "@electron-internal/*"
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@electron-internal/extract-zip": "^1.0.1",
     "@electron/get": "^4.0.2",
     "@electron/universal": "^3.0.1",
     "@tsconfig/node22": "^22.0.2",
     "@types/node": "~22.10.7",
-    "extract-zip": "^2.0.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "oxfmt": "^0.44.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@electron-internal/extract-zip": "^1.0.1",
+    "@electron-internal/extract-zip": "^1.0.2",
     "@electron/get": "^4.0.2",
     "@electron/universal": "^3.0.1",
     "@tsconfig/node22": "^22.0.2",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,5 +1,5 @@
 import { downloadArtifact } from '@electron/get';
-import extractZip from 'extract-zip';
+import { extract } from '@electron-internal/extract-zip';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -33,7 +33,7 @@ export async function getElectronLocally(version: string, platform: string, arch
     artifactName: 'electron',
   });
   const tmpDir = await getTmpDir();
-  await extractZip(electronZip, {
+  await extract(electronZip, {
     dir: tmpDir,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@electron-internal/extract-zip@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@electron-internal/extract-zip@npm:1.0.1"
+  checksum: 10c0/4149cb1c99da41457802a11fac692701f58460dcd78341958c10c948876abd3747d45137cf6bfe0c99e7dea0bdb32bf072e9d420a18f55bd1e0087bd1a5c45ba
+  languageName: node
+  linkType: hard
+
 "@electron/asar@npm:^4.0.0":
   version: 4.0.0
   resolution: "@electron/asar@npm:4.0.0"
@@ -22,11 +29,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@electron/fuses@workspace:."
   dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
     "@electron/get": "npm:^4.0.2"
     "@electron/universal": "npm:^3.0.1"
     "@tsconfig/node22": "npm:^22.0.2"
     "@types/node": "npm:~22.10.7"
-    extract-zip: "npm:^2.0.1"
     husky: "npm:^9.1.7"
     lint-staged: "npm:^16.1.2"
     oxfmt: "npm:^0.44.0"
@@ -724,7 +731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:~22.10.7":
+"@types/node@npm:~22.10.7":
   version: 22.10.10
   resolution: "@types/node@npm:22.10.10"
   dependencies:
@@ -737,15 +744,6 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
-  languageName: node
-  linkType: hard
-
-"@types/yauzl@npm:^2.9.1":
-  version: 2.10.0
-  resolution: "@types/yauzl@npm:2.10.0"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/e917cf11c78e9ca7d037d0e6e0d6d5d99443d9d7201f8f1a556f02a2bc57ae457487e9bfec89dfa848d16979b35de6e5b34840d4d0bb9e5f33849d077ac15154
   languageName: node
   linkType: hard
 
@@ -947,13 +945,6 @@ __metadata:
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10c0/7c6dfd30c338d2997ba77500539227b9d1f85e388a5f43220865201e407e076783d0881f2d297b9f80951b4c957fcf0b51c1d2d24227631643c3f7c284b0aa04
-  languageName: node
-  linkType: hard
-
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 10c0/cb0a8ddf5cf4f766466db63279e47761eb825693eeba6a5a95ee4ec8cb8f81ede70aa7f9d8aeec083e781d47154290eb5d4d26b3f7a465ec57fb9e7d59c47150
   languageName: node
   linkType: hard
 
@@ -1164,15 +1155,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: "npm:^1.4.0"
-  checksum: 10c0/870b423afb2d54bb8d243c63e07c170409d41e20b47eeef0727547aea5740bd6717aca45597a9f2745525667a6b804c1e7bede41f856818faee5806dd9ff3975
-  languageName: node
-  linkType: hard
-
 "entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
@@ -1235,32 +1217,6 @@ __metadata:
   version: 1.3.0
   resolution: "expect-type@npm:1.3.0"
   checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
-  languageName: node
-  linkType: hard
-
-"extract-zip@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 10c0/9afbd46854aa15a857ae0341a63a92743a7b89c8779102c3b4ffc207516b2019337353962309f85c66ee3d9092202a83cdc26dbf449a11981272038443974aee
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10c0/304dd70270298e3ffe3bcc05e6f7ade2511acc278bc52d025f8918b48b6aa3b77f10361bddfadfe2a28163f7af7adbdce96f4d22c31b2f648ba2901f0c5fc20e
   languageName: node
   linkType: hard
 
@@ -1339,15 +1295,6 @@ __metadata:
     has: "npm:^1.0.3"
     has-symbols: "npm:^1.0.3"
   checksum: 10c0/6f201d5f95ea0dd6c8d0dc2c265603aff0b9e15614cb70f8f4674bb3d2b2369d521efaa84d0b70451d2c00762ebd28402758bf46279c6f2a00d242ebac0d8442
-  languageName: node
-  linkType: hard
-
-"get-stream@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "get-stream@npm:5.2.0"
-  dependencies:
-    pump: "npm:^3.0.0"
-  checksum: 10c0/43797ffd815fbb26685bf188c8cfebecb8af87b3925091dd7b9a9c915993293d78e3c9e1bce125928ff92f2d0796f3889b92b5ec6d58d1041b574682132e0a80
   languageName: node
   linkType: hard
 
@@ -1907,15 +1854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.1, once@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "once@npm:1.4.0"
-  dependencies:
-    wrappy: "npm:1"
-  checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
-  languageName: node
-  linkType: hard
-
 "onetime@npm:^7.0.0":
   version: 7.0.0
   resolution: "onetime@npm:7.0.0"
@@ -2143,13 +2081,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pend@npm:~1.2.0":
-  version: 1.2.0
-  resolution: "pend@npm:1.2.0"
-  checksum: 10c0/8a87e63f7a4afcfb0f9f77b39bb92374afc723418b9cb716ee4257689224171002e07768eeade4ecd0e86f1fa3d8f022994219fb45634f2dbd78c6803e452458
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -2206,16 +2137,6 @@ __metadata:
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: 10c0/1697e07cb1068055dbe9fe858d242368ff5d2073639e652b75a7eb1f2a1a8d4afd404d719de23c7b48481a6aa0040686310e2dac2f53d776daa2176d3f96369c
-  languageName: node
-  linkType: hard
-
-"pump@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pump@npm:3.0.0"
-  dependencies:
-    end-of-stream: "npm:^1.1.0"
-    once: "npm:^1.3.1"
-  checksum: 10c0/bbdeda4f747cdf47db97428f3a135728669e56a0ae5f354a9ac5b74556556f5446a46f720a8f14ca2ece5be9b4d5d23c346db02b555f46739934cc6c093a5478
   languageName: node
   linkType: hard
 
@@ -2813,13 +2734,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrappy@npm:1":
-  version: 1.0.2
-  resolution: "wrappy@npm:1.0.2"
-  checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
-  languageName: node
-  linkType: hard
-
 "xmlbuilder@npm:^15.1.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
@@ -2833,16 +2747,6 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
-  dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10c0/f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@electron-internal/extract-zip@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@electron-internal/extract-zip@npm:1.0.1"
-  checksum: 10c0/4149cb1c99da41457802a11fac692701f58460dcd78341958c10c948876abd3747d45137cf6bfe0c99e7dea0bdb32bf072e9d420a18f55bd1e0087bd1a5c45ba
+"@electron-internal/extract-zip@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@electron-internal/extract-zip@npm:1.0.2"
+  checksum: 10c0/278455b486a6be7e04c4113fc19a5cc696151a19c32c62c63cf9e03ec2db95dcd32aafeaf3deac1d4e152442da9ff8e86914de9f17431f11071d62e171dc17a4
   languageName: node
   linkType: hard
 
@@ -29,7 +29,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@electron/fuses@workspace:."
   dependencies:
-    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron-internal/extract-zip": "npm:^1.0.2"
     "@electron/get": "npm:^4.0.2"
     "@electron/universal": "npm:^3.0.1"
     "@tsconfig/node22": "npm:^22.0.2"


### PR DESCRIPTION
Swaps the `extract-zip` dependency for the `@electron-internal/extract-zip` drop-in replacement.

- Renamed the dependency in `package.json` (`@electron-internal/extract-zip@^1.0.1`)
- Updated import/require specifiers in source
- Added `@electron-internal/*` to the npm age-gate allowlist in `.yarnrc.yml`
- Refreshed `yarn.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)